### PR TITLE
Fix bugs in data preparation and vpq evaluation

### DIFF
--- a/prepare_data/create_panoptic_labels.py
+++ b/prepare_data/create_panoptic_labels.py
@@ -81,15 +81,6 @@ def sem_inst2pan(sem_file, inst_file, id_converter, ori2fcn):
             continue
         pan_map[obj_mask] = fcn_id*1000 + obj_id
 
-    # Heuristics for the Ego-Centric Car
-    ego_map = label_map[int(label_map.shape[0]*0.7):,:]
-    ego_map[ego_map==VOID] = 0 # "ROAD"
-    label_map[int(label_map.shape[0]*0.7):,:] = ego_map
-
-    ego_map = pan_map[int(pan_map.shape[0]*0.7):,:]
-    ego_map[ego_map==VOID] = 0 # "ROAD"
-    pan_map[int(pan_map.shape[0]*0.7):,:] = ego_map
-
     return pan_map.astype(np.uint32), label_map.astype(np.uint8)
 
 def panoptic_multi_core(sem_files, inst_files, id_converter, ori2fcn):

--- a/prepare_data/create_panoptic_video_labels.py
+++ b/prepare_data/create_panoptic_video_labels.py
@@ -35,6 +35,7 @@ def panoptic_video_converter():
     annotations = []
     instid2color = {}
     videos = []
+    id_generator = IdGenerator(categories_dict)
     print('==> %s/panoptic_video/ ...'%(MODE)) 
 
     for idx in trange(len(file_list)):
@@ -55,7 +56,6 @@ def panoptic_video_converter():
                        "height": original_format.shape[0],
                        "file_name": image_filename})
         pan_format = np.zeros((original_format.shape[0], original_format.shape[1], 3), dtype=np.uint8)
-        id_generator = IdGenerator(categories_dict)
 
         l = np.unique(original_format)
 

--- a/tools/eval_vpq.py
+++ b/tools/eval_vpq.py
@@ -92,13 +92,13 @@ def vpq_compute_single_core(gt_pred_set, categories, nframes=2):
                 if el['id'] in gt_segms:
                     gt_segms[el['id']]['area'] += el['area']
                 else:
-                    gt_segms[el['id']] = el
+                    gt_segms[el['id']] = copy.deepcopy(el)
             pred_segms = {}
             for el in pred_json['segments_info']:
                 if el['id'] in pred_segms:
                     pred_segms[el['id']]['area'] += el['area']
                 else:
-                    pred_segms[el['id']] = el
+                    pred_segms[el['id']] = copy.deepcopy(el)
             # predicted segments area calculation + prediction sanity checks
             pred_labels_set = set(el['id'] for el in pred_json['segments_info'])
             labels, labels_cnt = np.unique(pan_pred, return_counts=True)


### PR DESCRIPTION
Thanks for your great work! We found 2 bugs when using it and provided our solution in this pull request.

* Fixed id collision when creating panoptic video labels
* Fixed data tampering in vpq evaluation

The id collision can happen when the id generator is initialized multiple times. It can cause different instances to have the same ids.

In VPQ evaluation, the data can be altered unintentionally if deepcopy is not used. It affects the PQs when the number of frames is greater than 2.

Please forgive us if what we described here is erroneous. Hope this pull request can be helpful.

Cheers!

P.S. The removal of the heuristics is only a suggestion. We found it had negative effects on both training and evaluation.